### PR TITLE
環境毎に利用するexecを分ける

### DIFF
--- a/exec_default.go
+++ b/exec_default.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	osexec "os/exec"
 	"os/signal"
@@ -17,7 +16,7 @@ func exec(command string, args []string, envv []string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Env = envv
 
-	signals := make([]os.Signal, 32)
+	signals := make([]os.Signal, 31)
 	for i := range signals {
 		signals[i] = syscall.Signal(i + 1)
 	}

--- a/exec_default.go
+++ b/exec_default.go
@@ -1,0 +1,47 @@
+// +build !linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"os/signal"
+	"syscall"
+)
+
+func exec(command string, args []string, envv []string) error {
+	cmd := osexec.Command(command, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = envv
+
+	signals := make([]os.Signal, 32)
+	for i := range signals {
+		signals[i] = syscall.Signal(i + 1)
+	}
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, signals...)
+
+	go func() {
+		sig := <-sigc
+		if cmd.Process != nil {
+			cmd.Process.Signal(sig)
+		}
+	}()
+
+	var waitStatus syscall.WaitStatus
+	if err := cmd.Run(); err != nil {
+		if err != nil {
+			return err
+		}
+		if exitError, ok := err.(*osexec.ExitError); ok {
+			waitStatus = exitError.Sys().(syscall.WaitStatus)
+			os.Exit(waitStatus.ExitStatus())
+		}
+	}
+
+	return nil
+}

--- a/exec_unix.go
+++ b/exec_unix.go
@@ -1,0 +1,21 @@
+// +build linux
+
+package main
+
+import (
+	osexec "os/exec"
+	"syscall"
+)
+
+func exec(command string, args []string, envv []string) error {
+	binary, err := osexec.LookPath(command)
+	if err != nil {
+		return err
+	}
+
+	argv := make([]string, 0, 1+len(args))
+	argv = append(argv, command)
+	argv = append(argv, args...)
+
+	return syscall.Exec(binary, argv, envv)
+}

--- a/grcron.go
+++ b/grcron.go
@@ -11,7 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
+	osexec "os/exec"
 	"runtime"
 )
 
@@ -59,10 +59,10 @@ func (gr grcron) keepalivedActive() (bool, error) {
 	if testKeepalivedActive != nil {
 		return testKeepalivedActive()
 	}
-	cmd := exec.Command("sh", "-c", "ps cax | grep -q keepalived")
+	cmd := osexec.Command("sh", "-c", "ps cax | grep -q keepalived")
 	err := cmd.Run()
 	// 異常終了はkeepalivedプロセスがいないとみなす
-	if _, ok := err.(*exec.ExitError); ok {
+	if _, ok := err.(*osexec.ExitError); ok {
 		return false, fmt.Errorf("keepalived is probably down")
 	}
 	return true, nil
@@ -124,14 +124,7 @@ func main() {
 		return
 	}
 
-	cmd := exec.Command(args[0], args[1:]...)
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err = cmd.Run()
-	if err != nil {
+	if err := exec(args[0], args[1:], os.Environ()); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
syscall.Execが使えない環境はexec.Commandを使い、シグナルも伝播させる。grcronは単に実行可否の判断だけの用途なので、シグナルが伝播されないと利便性に欠けると思われる。
マルチスレッドなのでsyscall.Execが安全かわからないけどlinuxなら使うようにしてみる。

syscall.Execを使うメリット
- 標準入出力などのin/outやシグナルハンドリングを考慮しなくて良い

syscall.Execの使った場合の心配
- |'-') golangでは安全なの？、情報求む

|'-') oO( keepalived前提(引数でプロセス名指定でも良い？)なのでwindows,darwinは考慮する必要なさそうだけど、環境毎にコード分けるのを試してみたいので分けてみる )
